### PR TITLE
Make kill message colour consistent with item name, allow customizing message

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/civchat2/listeners/KillListener.java
+++ b/paper/src/main/java/vg/civcraft/mc/civchat2/listeners/KillListener.java
@@ -56,7 +56,12 @@ public class KillListener implements Listener {
 			if (!hasWordBank) {
 				displayName = String.format("with a %s", itemName);
 			} else {
-				displayName = String.format("with %s", displayName);
+				String killMessageFormat = settingsMan.getKillMessageFormat(killer.getUniqueId()).simpleDescription;
+				if (killMessageFormat.isBlank()) {
+					displayName = String.format("%s%s", killMessageFormat, displayName);
+				} else {
+					displayName = String.format("%s %s", killMessageFormat, displayName);
+				}
 			}
 
 			msg = String.format("%s%s %swas killed by %s %s%s", ChatColor.DARK_GRAY, victimFormattedName,

--- a/paper/src/main/java/vg/civcraft/mc/civchat2/listeners/KillListener.java
+++ b/paper/src/main/java/vg/civcraft/mc/civchat2/listeners/KillListener.java
@@ -40,9 +40,12 @@ public class KillListener implements Listener {
 		}
 		String msg;
 		ItemStack item = killer.getInventory().getItemInMainHand();
+		String victimFormattedName = String.format("%s%s", ChatColor.ITALIC, victim.getDisplayName());
+		String killerFormattedName = String.format("%s%s", ChatColor.ITALIC, killer.getDisplayName());
+
 		if (item == null || MaterialUtils.isAir(item.getType())) {
-			msg = String.format("%s%s was killed by %s by hand", ChatColor.DARK_GRAY, victim.getDisplayName(),
-					killer.getDisplayName());
+			msg = String.format("%s%s %swas killed by %s %sby hand", ChatColor.DARK_GRAY, victimFormattedName,
+					ChatColor.DARK_GRAY, killerFormattedName, ChatColor.DARK_GRAY);
 		} else {
 			String itemName = ItemUtils.getItemName(item);
 			String displayName = ItemUtils.getDisplayName(item);
@@ -55,8 +58,6 @@ public class KillListener implements Listener {
 			} else {
 				displayName = String.format("with %s", displayName);
 			}
-			String victimFormattedName = String.format("%s%s", ChatColor.ITALIC, victim.getDisplayName());
-			String killerFormattedName = String.format("%s%s", ChatColor.ITALIC, killer.getDisplayName());
 
 			msg = String.format("%s%s %swas killed by %s %s%s", ChatColor.DARK_GRAY, victimFormattedName,
 					ChatColor.DARK_GRAY, killerFormattedName, ChatColor.DARK_GRAY, displayName);

--- a/paper/src/main/java/vg/civcraft/mc/civchat2/listeners/KillListener.java
+++ b/paper/src/main/java/vg/civcraft/mc/civchat2/listeners/KillListener.java
@@ -1,5 +1,6 @@
 package vg.civcraft.mc.civchat2.listeners;
 
+import java.util.Optional;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -40,22 +41,25 @@ public class KillListener implements Listener {
 		String msg;
 		ItemStack item = killer.getInventory().getItemInMainHand();
 		if (item == null || MaterialUtils.isAir(item.getType())) {
-			msg = String.format("%s%s was killed by %s by hand", ChatColor.DARK_RED, victim.getDisplayName(), killer.getDisplayName());
+			msg = String.format("%s%s was killed by %s by hand", ChatColor.DARK_GRAY, victim.getDisplayName(),
+					killer.getDisplayName());
 		} else {
 			String itemName = ItemUtils.getItemName(item);
 			String displayName = ItemUtils.getDisplayName(item);
-			Boolean isEnchanted = ItemUtils.getItemMeta(item).hasEnchants();
-			Boolean isRenamed = displayName != null && displayName != "";
-			if (isEnchanted && !isRenamed) {
-				displayName = String.format("with %s%s", ChatColor.AQUA, itemName);
-			} else if (isEnchanted && isRenamed) {
-				displayName = String.format("with %s%s%s", ChatColor.AQUA, ChatColor.ITALIC, displayName);
-			} else if (!isEnchanted && isRenamed) {
-				displayName = String.format("with %s%s%s", ChatColor.WHITE, ChatColor.ITALIC, displayName);
-			} else if (!isEnchanted && !isRenamed) {
-				displayName = String.format("with %s%s", ChatColor.WHITE, itemName);
+			Boolean hasWordBank = Optional.ofNullable(ItemUtils.getItemMeta(item))
+					.map(r -> r.displayName())
+					.map(f -> f.children().size() > 0)
+					.orElse(false);
+			if (!hasWordBank) {
+				displayName = String.format("with a %s", itemName);
+			} else {
+				displayName = String.format("with %s", displayName);
 			}
-			msg = String.format("%s%s was killed by %s %s", ChatColor.DARK_RED, victim.getDisplayName(), killer.getDisplayName(), displayName);
+			String victimFormattedName = String.format("%s%s", ChatColor.ITALIC, victim.getDisplayName());
+			String killerFormattedName = String.format("%s%s", ChatColor.ITALIC, killer.getDisplayName());
+
+			msg = String.format("%s%s %swas killed by %s %s%s", ChatColor.DARK_GRAY, victimFormattedName,
+					ChatColor.DARK_GRAY, killerFormattedName, ChatColor.DARK_GRAY, displayName);
 		}
 		Location killLoc = victim.getLocation();
 		for (Player p : Bukkit.getOnlinePlayers()) {

--- a/paper/src/main/java/vg/civcraft/mc/civchat2/listeners/KillListener.java
+++ b/paper/src/main/java/vg/civcraft/mc/civchat2/listeners/KillListener.java
@@ -37,23 +37,27 @@ public class KillListener implements Listener {
 		if (!settingsMan.getSendOwnKills(killer.getUniqueId())) {
 			return;
 		}
-		String itemDescriptor;
+		String msg;
 		ItemStack item = killer.getInventory().getItemInMainHand();
 		if (item == null || MaterialUtils.isAir(item.getType())) {
-			itemDescriptor = "by hand";
-		}
-		else {
+			msg = String.format("%s%s was killed by %s by hand", ChatColor.DARK_RED, victim.getDisplayName(), killer.getDisplayName());
+		} else {
+			String itemName = ItemUtils.getItemName(item);
 			String displayName = ItemUtils.getDisplayName(item);
-			if (displayName == null) {
-				itemDescriptor = "with " + ItemUtils.getItemName(item);
+			Boolean isEnchanted = ItemUtils.getItemMeta(item).hasEnchants();
+			Boolean isRenamed = displayName != null && displayName != "";
+			if (isEnchanted && !isRenamed) {
+				displayName = String.format("with %s%s", ChatColor.AQUA, itemName);
+			} else if (isEnchanted && isRenamed) {
+				displayName = String.format("with %s%s%s", ChatColor.AQUA, ChatColor.ITALIC, displayName);
+			} else if (!isEnchanted && isRenamed) {
+				displayName = String.format("with %s%s%s", ChatColor.WHITE, ChatColor.ITALIC, displayName);
+			} else if (!isEnchanted && !isRenamed) {
+				displayName = String.format("with %s%s", ChatColor.WHITE, itemName);
 			}
-			else {
-				itemDescriptor = "with " + displayName;
-			}
+			msg = String.format("%s%s was killed by %s %s", ChatColor.DARK_RED, victim.getDisplayName(), killer.getDisplayName(), displayName);
 		}
 		Location killLoc = victim.getLocation();
-		String msg = String.format("%s%s was killed by %s%s %s", victim.getDisplayName(), ChatColor.GOLD, killer.getDisplayName(),
-				ChatColor.GOLD, itemDescriptor);
 		for (Player p : Bukkit.getOnlinePlayers()) {
 			Location loc = p.getLocation();
 			if (!loc.getWorld().equals(killLoc.getWorld())) {

--- a/paper/src/main/java/vg/civcraft/mc/civchat2/utility/CivChat2SettingsManager.java
+++ b/paper/src/main/java/vg/civcraft/mc/civchat2/utility/CivChat2SettingsManager.java
@@ -8,6 +8,7 @@ import vg.civcraft.mc.civmodcore.players.settings.PlayerSettingAPI;
 import vg.civcraft.mc.civmodcore.players.settings.gui.MenuSection;
 import vg.civcraft.mc.civmodcore.players.settings.impl.BooleanSetting;
 import vg.civcraft.mc.civmodcore.players.settings.impl.DisplayLocationSetting;
+import vg.civcraft.mc.civmodcore.players.settings.impl.EnumSetting;
 import vg.civcraft.mc.civmodcore.players.settings.impl.LongSetting;
 
 public class CivChat2SettingsManager {
@@ -20,6 +21,7 @@ public class CivChat2SettingsManager {
 	private BooleanSetting showChatGroup;
 	private DisplayLocationSetting chatGroupLocation;
 	private LongSetting chatUnmuteTimer;
+	private EnumSetting<KillMessageFormat> killMessageFormat;
 
 	public CivChat2SettingsManager() {
 		initSettings();
@@ -60,6 +62,9 @@ public class CivChat2SettingsManager {
 		
 		chatUnmuteTimer = new LongSetting(CivChat2.getInstance(), 0L, "Global chat mute", "chatGlobalMuteTimer");
 		PlayerSettingAPI.registerSetting(chatUnmuteTimer, null);
+
+		killMessageFormat = new EnumSetting<>(CivChat2.getInstance(), KillMessageFormat.WITH, "Kill Message Format", "killMessageFormat", new ItemStack(Material.WRITABLE_BOOK), "Choose your kill message format", true, KillMessageFormat.class);
+		PlayerSettingAPI.registerSetting(killMessageFormat, menu);
 	}
 	
 	public LongSetting getGlobalChatMuteSetting() {
@@ -92,5 +97,36 @@ public class CivChat2SettingsManager {
 
 	public DisplayLocationSetting getChatGroupLocation() {
 		return chatGroupLocation;
+	}
+
+	public KillMessageFormat getKillMessageFormat(UUID uuid) {
+		return killMessageFormat.getValue(uuid);
+	}
+
+	public enum KillMessageFormat {
+		FOR(
+			"for"
+			),
+		WHILE(
+			"while"
+		),
+		BLANK(
+			""
+		),
+		USING(
+			"using"
+		),
+		BY(
+			"by"
+		),
+		WITH(
+			"with"
+		);
+
+		public final String simpleDescription;
+
+		private KillMessageFormat(String simpleDescription) {
+			this.simpleDescription = simpleDescription;
+		}	
 	}
 }


### PR DESCRIPTION
With the introduction of wordbank and global kill messages, I decided to rewrite how the message colouring is determined to make it consistent with the ingame item name. I also changed the message colour to DARK_RED as it isn't in the wordbank config. There was also a bug with unnamed items not displaying that is now fixed.

These images show the before and after for the following scenarios
1. Wordbanked item
2. Renamed & Enchanted item
3. Enchanted item
4. Renamed item
5. Default item
6. Punched

![2023-07-20_17 03 41](https://github.com/CivMC/CivChat2/assets/14056973/75ad269d-f005-43c7-9e97-79cecc2434a1)
![2023-07-20_17 00 48](https://github.com/CivMC/CivChat2/assets/14056973/00a6103d-f9d1-43cd-8d8e-1026dcc87f32)
